### PR TITLE
add support for editing unavailable chapters

### DIFF
--- a/mangadex_mass_uploader/mangadex_api.py
+++ b/mangadex_mass_uploader/mangadex_api.py
@@ -179,6 +179,7 @@ class MangaDexAPI(metaclass=Singleton):
         # some hardcoded params
         filters["limit"] = 100
         filters["offset"] = 0
+        filters["includeUnavailable"] = 1
         filters["contentRating[]"] = ["safe", "suggestive", "erotica", "pornographic"]
         # replace None with "none" for volumes
         if filters["volume[]"] is not None:


### PR DESCRIPTION
From my understanding, adding this parameter should allow the editor to retrieve and consequently edit unavailable chapters.
However, unavailable chapters will always be returned with this change, so an additional filter to toggle this behaviour might be useful... 